### PR TITLE
TokenGeneratorのイテレータのItemの型をResultでラップした

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -7,11 +7,31 @@ pub mod token_gen;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-enum Error {
+enum _Error {
     /// オーバーフローを含む
     #[error("line {line}: Token \"{token}\" cannot parse to integer.")]
     ParseIntError {
         line: usize,
         token: String,
     },
+}
+
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct Error {
+    #[from]
+    inner: _Error,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn error_test() {
+        let e = Error {
+            inner: _Error::ParseIntError { line: 1, token: "100a".to_owned() },
+        };
+        assert_eq!(e.to_string(), "line 1: Token \"100a\" cannot parse to integer.");
+    }
 }

--- a/src/lex/token_gen.rs
+++ b/src/lex/token_gen.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 /// 演算子のリスト
-const OPERATORS: [&'static str; 8] = ["#", "*", ";", "(", ")", "[", "]", ":"];
+const OPERATORS: [&str; 8] = ["#", "*", ";", "(", ")", "[", "]", ":"];
 
 // トークン型のvariantの型は要検討
 // 型の候補↓
@@ -39,7 +39,7 @@ impl<C: Iterator<Item = io::Result<char>>> TokenGenerator<C> {
 }
 
 impl<C: Iterator<Item = io::Result<char>>> Iterator for TokenGenerator<C> {
-    type Item = Token;
+    type Item = Result<Token, super::Error>;
     fn next(&mut self) -> Option<Self::Item> {
         unimplemented!()
     }


### PR DESCRIPTION
# 変更点
* エラー型をpublicにした
* `<TokenGenerator<_> as Iterator>::Item`を`Result<Token, Error>`に変更した