### PR TITLE
WordGeneratorを実装,CharGeneratorのリファクタリング

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      
+    }
+  }
+}

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -3,6 +3,7 @@
 pub mod ast;
 pub mod char_gen;
 pub mod token_gen;
+pub mod word_gen;
 
 use thiserror::Error;
 

--- a/src/lex/char_gen.rs
+++ b/src/lex/char_gen.rs
@@ -34,7 +34,6 @@ impl<C: Iterator<Item = io::Result<char>>> CharGenerator<C> {
 }
 
 impl<'a, R: BufRead> CharGenerator<utf8_chars::Chars<'a, R>> {
-    /// panicする可能性があるので、テスト時のみ使用
     pub fn new(reader: &'a mut R) -> Self {
         let mut chars = reader.chars();
         Self {
@@ -94,7 +93,7 @@ pub trait CharGeneratorTrait {
         Chars { inner: self }
     }
 
-    /// predicateがfalseを返すまでの文字を取り出す。
+    /// `predicate`が`false`を返すまでの文字を取り出す。
     fn take_while<P>(&mut self, predicate: P) -> TakeWhile<Self, P>
     where
         P: FnMut(char) -> bool,
@@ -105,6 +104,7 @@ pub trait CharGeneratorTrait {
         }
     }
 
+    /// `predicate`に`self`を使いたい場合に使う。`self`を使わない場合は`take_while`関数を使う。
     fn take_while_with_self<P>(&mut self, predicate: P) -> TakeWhileWithSelf<Self, P>
     where
         P: FnMut(&mut Self, char) -> bool,
@@ -115,7 +115,7 @@ pub trait CharGeneratorTrait {
         }
     }
 
-    /// predicateがtrueを返している間、文字をスキップする。
+    /// `predicate`が`true`を返している間、文字をスキップする。
     fn skip_while<P>(&mut self, mut predicate: P)
     where
         P: FnMut(Result<char, EncodeError>) -> bool,
@@ -145,7 +145,7 @@ pub trait CharGeneratorTrait {
         }
     }
 
-    /// fを満たす文字を読み飛ばす。
+    /// `f`を満たす文字を読み飛ばす。
     fn consume_with<F: FnOnce(char) -> bool>(&mut self, f: F) -> bool {
         if let Some(Ok(c)) = self.peek() {
             if f(c) {

--- a/src/lex/char_gen.rs
+++ b/src/lex/char_gen.rs
@@ -2,12 +2,13 @@ use std::io::{self, BufRead};
 
 use utf8_chars::BufReadCharsExt;
 
-use super::token_gen::TokenGenerator;
+use super::{token_gen::TokenGenerator, word_gen::WordGenerator};
 
 /// 位置情報付きの文字のイテレータ
 #[derive(Clone, Debug)]
 pub struct CharGenerator<C> {
     chars: C,
+    current: Option<Result<char, EncodeError>>,
     line: usize,
     column: usize,
 }
@@ -26,19 +27,18 @@ impl<C> CharGenerator<C> {
     }
 }
 
-impl<'a, R: BufRead> From<&'a mut R> for CharGenerator<utf8_chars::Chars<'a, R>> {
-    fn from(value: &'a mut R) -> Self {
-        Self {
-            chars: value.chars(),
-            line: 1,
-            column: 1,
-        }
+impl<C: Iterator<Item = io::Result<char>>> CharGenerator<C> {
+    pub fn into_word_generator(self) -> WordGenerator<Self> {
+        WordGenerator::new(self)
     }
 }
 
 impl<'a, R: BufRead> CharGenerator<utf8_chars::Chars<'a, R>> {
+    /// panicする可能性があるので、テスト時のみ使用
     pub fn new(reader: &'a mut R) -> Self {
+        let mut chars = reader.chars();
         Self {
+            current: chars.next().map(|r| r.map_err(|_| EncodeError)),
             chars: reader.chars(),
             line: 1,
             column: 1,
@@ -47,20 +47,166 @@ impl<'a, R: BufRead> CharGenerator<utf8_chars::Chars<'a, R>> {
 }
 
 impl<C: Iterator<Item = io::Result<char>>> Iterator for CharGenerator<C> {
-    type Item = C::Item;
+    type Item = Result<char, EncodeError>;
     fn next(&mut self) -> Option<Self::Item> {
-        let c = self.chars.next();
-        match c {
+        self.next_char()
+    }
+}
+
+impl<C: Iterator<Item = io::Result<char>>> CharGeneratorTrait for CharGenerator<C> {
+    fn reader_position(&self) -> (usize, usize) {
+        (self.line, self.column)
+    }
+
+    fn next_char(&mut self) -> Option<Result<char, EncodeError>> {
+        match std::mem::replace(
+            &mut self.current,
+            self.chars.next().map(|r| r.map_err(|_| EncodeError)),
+        ) {
             Some(Ok('\n')) => {
                 self.line += 1;
                 self.column = 1;
+                Some(Ok('\n'))
             }
-            Some(Ok(_)) => {
+            Some(Ok(c)) => {
                 self.column += 1;
+                Some(Ok(c))
             }
-            _ => {}
+            c => c,
         }
-        c
+    }
+
+    fn peek(&mut self) -> Option<Result<char, EncodeError>> {
+        self.current
+    }
+}
+
+pub trait CharGeneratorTrait {
+    /// 現在の行と列を返す
+    fn reader_position(&self) -> (usize, usize);
+    /// 次の文字を読み進める。
+    fn next_char(&mut self) -> Option<Result<char, EncodeError>>;
+    /// 次の文字を、読み進めずに返す。
+    fn peek(&mut self) -> Option<Result<char, EncodeError>>;
+
+    /// 文字のイテレータを返す。
+    fn chars(&mut self) -> Chars<Self> {
+        Chars { inner: self }
+    }
+
+    /// predicateがfalseを返すまでの文字を取り出す。
+    fn take_while<P>(&mut self, predicate: P) -> TakeWhile<Self, P>
+    where
+        P: FnMut(char) -> bool,
+    {
+        TakeWhile {
+            inner: self,
+            predicate,
+        }
+    }
+
+    fn take_while_with_self<P>(&mut self, predicate: P) -> TakeWhileWithSelf<Self, P>
+    where
+        P: FnMut(&mut Self, char) -> bool,
+    {
+        TakeWhileWithSelf {
+            inner: self,
+            predicate,
+        }
+    }
+
+    /// predicateがtrueを返している間、文字をスキップする。
+    fn skip_while<P>(&mut self, mut predicate: P)
+    where
+        P: FnMut(Result<char, EncodeError>) -> bool,
+    {
+        while self.peek().map_or(false, &mut predicate) {
+            self.next_char();
+        }
+    }
+
+    /// 改行以外の空白文字をスキップする。
+    fn skip_spaces(&mut self) {
+        self.skip_while(|c| c.map_or(false, |c| c.is_ascii_whitespace() && c != '\n'))
+    }
+
+    /// 空白文字をスキップする。
+    fn skip_whitespaces(&mut self) {
+        self.skip_while(|c| c.map_or(false, |c| c.is_ascii_whitespace()))
+    }
+
+    /// 指定した文字を読み飛ばす。
+    fn consume(&mut self, c: char) -> bool {
+        if self.peek() == Some(Ok(c)) {
+            self.next_char();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// fを満たす文字を読み飛ばす。
+    fn consume_with<F: FnOnce(char) -> bool>(&mut self, f: F) -> bool {
+        if let Some(Ok(c)) = self.peek() {
+            if f(c) {
+                self.next_char();
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("エンコードできない文字が含まれています。")]
+pub struct EncodeError;
+
+pub struct TakeWhile<'a, C: CharGeneratorTrait + ?Sized, P: FnMut(char) -> bool> {
+    inner: &'a mut C,
+    predicate: P,
+}
+
+impl<'a, C: CharGeneratorTrait + ?Sized, P: FnMut(char) -> bool> Iterator for TakeWhile<'a, C, P> {
+    type Item = char;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.peek() {
+            Some(Ok(c)) if (self.predicate)(c) => {
+                self.inner.next_char();
+                Some(c)
+            }
+            _ => None,
+        }
+    }
+}
+
+pub struct TakeWhileWithSelf<'a, C: CharGeneratorTrait + ?Sized, P: FnMut(&mut C, char) -> bool> {
+    inner: &'a mut C,
+    predicate: P,
+}
+
+impl<'a, C: CharGeneratorTrait + ?Sized, P: FnMut(&mut C, char) -> bool> Iterator
+    for TakeWhileWithSelf<'a, C, P>
+{
+    type Item = char;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.peek() {
+            Some(Ok(c)) if (self.predicate)(self.inner, c) => {
+                self.inner.next_char();
+                Some(c)
+            }
+            _ => None,
+        }
+    }
+}
+
+pub struct Chars<'a, T: CharGeneratorTrait + ?Sized> {
+    inner: &'a mut T,
+}
+
+impl<'a, T: CharGeneratorTrait + ?Sized> Iterator for Chars<'a, T> {
+    type Item = Result<char, EncodeError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next_char()
     }
 }
 
@@ -70,34 +216,16 @@ mod test {
     use super::*;
 
     #[test]
-    #[should_panic]
-    fn char_test() {
-        let a = 0xfff10a52u32;
-        println!("{:?}", char::from_u32(a).unwrap());
-    }
-
-    #[test]
     fn char_generator_test() {
         let mut buf = "你好，世界！\nHello, world!\n".as_bytes();
         let mut chars = CharGenerator::new(&mut buf);
-        assert_eq!(chars.next().unwrap().unwrap(), '你');
-        assert_eq!(chars.next().unwrap().unwrap(), '好');
-        assert_eq!(chars.next().unwrap().unwrap(), '，');
-    }
-
-    #[test]
-    #[should_panic]
-    fn char_generator_error() {
-        let mut buf = [0xff, 0xff, 0xff, 0xff, 0xff, 0xff].as_ref();
-        let mut chars = CharGenerator::new(&mut buf);
-
-        // イメージ的にはエラー処理はこんな感じになると想定
-        let _c = match chars.next().unwrap() {
-            Ok(c) => c,
-            Err(e) => {
-                // invalid dataとしか表示されないので、自作エラー型を作りたい
-                panic!("{}", e);
-            }
-        };
+        assert_eq!(chars.next_char().unwrap().unwrap(), '你');
+        assert_eq!(chars.next_char().unwrap().unwrap(), '好');
+        assert_eq!(chars.next_char().unwrap().unwrap(), '，');
+        assert!(chars.consume('世'));
+        assert!(chars.consume('界'));
+        assert!(chars.consume('！'));
+        chars.skip_whitespaces();
+        assert!(chars.consume('H'));
     }
 }

--- a/src/lex/word_gen.rs
+++ b/src/lex/word_gen.rs
@@ -1,0 +1,212 @@
+use std::collections::HashSet;
+
+use super::char_gen::{CharGeneratorTrait, EncodeError};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Word {
+    Word(Box<str>),
+    Separator(char),
+    NewLine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct Separators {
+    inner: Option<HashSet<char>>,
+}
+
+impl Separators {
+    fn add(&mut self, separator: char) {
+        if let Some(inner) = &mut self.inner {
+            inner.insert(separator);
+        } else {
+            self.inner = Some(
+                Self::default_separators()
+                    .iter()
+                    .copied()
+                    .chain(std::iter::once(separator))
+                    .collect(),
+            );
+        }
+    }
+
+    fn extend<I: IntoIterator<Item = char>>(&mut self, itr: I) {
+        if let Some(inner) = &mut self.inner {
+            inner.extend(itr);
+        } else {
+            self.inner = Some(
+                Self::default_separators()
+                    .iter()
+                    .copied()
+                    .chain(itr)
+                    .collect(),
+            );
+        }
+    }
+
+    fn default_separators() -> &'static [char] {
+        &[
+            ',', '$', '!', '?', '(', ')', '[', ']', '{', '}', '<', '>', '=', '+', '-', '*', '/',
+            '%', '^', '&', '|', '~', '@', '#', ';', ':', '.', '"', '\'', '`', '\\',
+        ]
+    }
+
+    pub fn is_separator(&self, c: char) -> bool {
+        if let Some(inner) = &self.inner {
+            inner.contains(&c)
+        } else {
+            Self::default_separators().contains(&c)
+        }
+    }
+
+    pub fn remove(&mut self, separator: char) {
+        if let Some(inner) = &mut self.inner {
+            inner.remove(&separator);
+        } else if Self::default_separators().contains(&separator) {
+            self.inner = Some(
+                Self::default_separators()
+                    .iter()
+                    .copied()
+                    .filter(|c| *c != separator)
+                    .collect(),
+            );
+        }
+    }
+}
+
+pub struct WordGenerator<C: CharGeneratorTrait> {
+    char_gen: C,
+    separators: Separators,
+}
+
+impl<C: CharGeneratorTrait> WordGenerator<C> {
+    pub fn new(char_gen: C) -> Self {
+        Self {
+            char_gen,
+            separators: Default::default(),
+        }
+    }
+
+    pub fn add_separator(&mut self, separator: char) {
+        self.separators.add(separator);
+    }
+
+    pub fn add_separators<I: IntoIterator<Item = char>>(&mut self, itr: I) {
+        self.separators.extend(itr);
+    }
+
+    pub fn default_separators() -> &'static [char] {
+        &[
+            ',', '$', '!', '?', '(', ')', '[', ']', '{', '}', '<', '>', '=', '+', '-', '*', '/',
+            '%', '^', '&', '|', '~', '@', '#', ';', ':', '.', '"', '\'', '`', '\\',
+        ]
+    }
+
+    pub fn remove_separator(&mut self, separator: char) {
+        self.separators.remove(separator);
+    }
+}
+
+impl<C: CharGeneratorTrait> WordGeneratorTrait for WordGenerator<C> {
+    fn is_separator(&self, c: char) -> bool {
+        self.separators.is_separator(c)
+    }
+}
+
+impl<C: CharGeneratorTrait> CharGeneratorTrait for WordGenerator<C> {
+    fn next_char(&mut self) -> Option<Result<char, EncodeError>> {
+        self.char_gen.next_char()
+    }
+
+    fn peek(&mut self) -> Option<Result<char, EncodeError>> {
+        self.char_gen.peek()
+    }
+
+    fn reader_position(&self) -> (usize, usize) {
+        self.char_gen.reader_position()
+    }
+}
+
+pub trait WordGeneratorTrait: CharGeneratorTrait {
+    /// 区切り文字であるかどうかを判定する。
+    fn is_separator(&self, c: char) -> bool;
+
+    /// 改行以外の空白文字を無視し、Word単位に分割して読み進める。
+    /// Wordは、改行、区切り文字、単語の3種類がある。
+    fn next_word(&mut self) -> Option<Result<Word, EncodeError>> {
+        self.skip_spaces();
+        self.next_char().map(|x| match x {
+            Ok('\n') => Ok(Word::NewLine),
+            Ok(c) if self.is_separator(c) => Ok(Word::Separator(c)),
+            Ok(c) => Ok(Word::Word(
+                std::iter::once(c)
+                    .chain(self.take_while_with_self(|this, c| {
+                        !(this.is_separator(c) || c.is_ascii_whitespace())
+                    }))
+                    .collect::<String>()
+                    .into_boxed_str(),
+            )),
+            Err(_) => Err(EncodeError),
+        })
+    }
+
+    fn gen_encode_error(&self) -> super::Error {
+        let (line, column) = self.reader_position();
+        super::Error::new_encode_error(line, column)
+    }
+
+    /// Wordのイテレータを返す。
+    fn words(&mut self) -> Words<Self> {
+        Words { word_gen: self }
+    }
+
+    /// 次に来るWordが単語なら、その単語を返す。
+    fn expect_word(&mut self) -> Result<Box<str>, Option<Result<Word, EncodeError>>> {
+        match self.next_word() {
+            Some(Ok(Word::Word(w))) => Ok(w),
+            w => Err(w),
+        }
+    }
+}
+
+pub struct Words<'a, W: WordGeneratorTrait + ?Sized> {
+    word_gen: &'a mut W,
+}
+
+impl<'a, W: WordGeneratorTrait + ?Sized> Iterator for Words<'a, W> {
+    type Item = Result<Word, EncodeError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.word_gen.next_word()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::lex::char_gen::CharGenerator;
+
+    use super::*;
+
+    #[test]
+    fn word_gen_test() {
+        let mut buf = b"abc def".as_ref();
+        let mut gen = CharGenerator::new(&mut buf).into_word_generator();
+        assert_eq!(gen.next_word(), Some(Ok(Word::Word("abc".into()))));
+        assert_eq!(gen.next_word(), Some(Ok(Word::Word("def".into()))));
+
+        let mut buf = b"abc def\xFF ieo,;:@ovd123+233@0_0)".as_ref();
+        let mut gen = CharGenerator::new(&mut buf).into_word_generator();
+        assert_eq!(gen.expect_word(), Ok("abc".into()));
+        assert_eq!(gen.expect_word(), Ok("def".into()));
+        assert_eq!(gen.expect_word(), Err(Some(Err(EncodeError))));
+        assert_eq!(gen.expect_word(), Ok("ieo".into()));
+        assert_eq!(gen.expect_word(), Err(Some(Ok(Word::Separator(',')))));
+        assert!(gen.consume(';'));
+        assert!(gen.consume(':'));
+        assert!(!gen.consume('d'));
+        assert!(gen.consume('@'));
+        assert_eq!(gen.expect_word(), Ok("ovd123".into()));
+        gen.skip_while(|c| c != Ok('@'));
+        assert!(gen.consume('@'));
+
+        // println!("WordGeneratorTrait::expect_wordが返す値のサイズ: {} byte", std::mem::size_of_val(&gen.expect_word()));
+    }
+}

--- a/src/lex/word_gen.rs
+++ b/src/lex/word_gen.rs
@@ -130,8 +130,8 @@ pub trait WordGeneratorTrait: CharGeneratorTrait {
     /// 区切り文字であるかどうかを判定する。
     fn is_separator(&self, c: char) -> bool;
 
-    /// 改行以外の空白文字を無視し、Word単位に分割して読み進める。
-    /// Wordは、改行、区切り文字、単語の3種類がある。
+    /// 改行以外の空白文字を無視し、`Word`単位に分割して読み進める。
+    /// `Word`は、改行、区切り文字、単語の3種類がある。
     fn next_word(&mut self) -> Option<Result<Word, EncodeError>> {
         self.skip_spaces();
         self.next_char().map(|x| match x {
@@ -154,12 +154,12 @@ pub trait WordGeneratorTrait: CharGeneratorTrait {
         super::Error::new_encode_error(line, column)
     }
 
-    /// Wordのイテレータを返す。
+    /// `Word`のイテレータを返す。
     fn words(&mut self) -> Words<Self> {
         Words { word_gen: self }
     }
 
-    /// 次に来るWordが単語なら、その単語を返す。
+    /// 次に来る`Word`が単語なら、その単語を返す。
     fn expect_word(&mut self) -> Result<Box<str>, Option<Result<Word, EncodeError>>> {
         match self.next_word() {
             Some(Ok(Word::Word(w))) => Ok(w),


### PR DESCRIPTION
# 変更点

* `CharGenerator`の機能をトレイト化し、様々な機能を追加
* 区切り文字を指定し、ワード単位に区切るための`WordGeneratorTrait`を作成
* `WordGenerator`を作成し、`WordGeneratorTrait`を実装
* テストケースの追加、古いテストケースの削除
* コメントの追加